### PR TITLE
Use chokidar ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ignoring-watcher
 ===============
 This module allows you to create a directory tree watcher while ignoring specific directories/files based on [.gitignore rules](http://git-scm.com/docs/gitignore). Instead of specifying which files/directories to watch it is often more convenient to specify which files/directories to _not_ watch.
 
-Internally, this module uses [chokidar](https://github.com/paulmillr/chokidar) for crowss-OS file watching and the [minimatch](https://www.npmjs.com/package/minimatch) module is used to filter out ignored files.
+Internally, this module uses [chokidar](https://github.com/paulmillr/chokidar) for cross-OS file watching and the [minimatch](https://www.npmjs.com/package/minimatch) module is used to filter out ignored files.
 
 # Usage
 

--- a/lib/Watcher.js
+++ b/lib/Watcher.js
@@ -3,8 +3,6 @@ var EventEmitter = require('events').EventEmitter;
 var ignore = require('./ignore');
 var fs = require('fs');
 
-require('raptor-polyfill/string/startsWith');
-
 var events = [
     'add',
     'addDir',
@@ -39,16 +37,13 @@ function Watcher(options) {
     var ignorePatterns = ignore.loadIgnorePatterns(options);
 
     function watchDir(dir) {
-        var ignoredFilter = ignore.createIgnoredFilter(ignorePatterns, dir);
-
-        var watcher = chokidar.watch(
-            dir,
-            {
-                ignored: ignoredFilter,
-                persistent: options.persistent !== false,
-                usePolling: false,
-                ignoreInitial: true
-            });
+        var watcher = chokidar.watch(dir, {
+            ignored: ignorePatterns,
+            cwd: dir,
+            persistent: (options.persistent !== false),
+            usePolling: false,
+            ignoreInitial: true
+        });
 
         events.forEach(function(event) {
             watcher.on(event, function(path) {

--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -1,11 +1,4 @@
-var Minimatch = require('minimatch').Minimatch;
 var fs = require('fs');
-
-var MINIMATCH_OPTIONS = {
-    matchBase: true,
-    dot: true,
-    flipNegate: true
-};
 
 function loadIgnoreFile(ignoreFile) {
     var lines = fs.readFileSync(
@@ -13,13 +6,29 @@ function loadIgnoreFile(ignoreFile) {
         'utf8')
         .split(/\s*\r?\n\s*/);
 
-    for (var i = 0; i < lines.length; i++) {
-        var line = lines[i];
-        if ((line.indexOf('/') !== -1) && (line.charAt(0) !== '/')) {
-            lines[i] = '/' + line;
+
+    return lines.map(function(line) {
+        line = line.trim();
+
+        if (line.length === 0) {
+            // empty line
+            return line;
         }
-    }
-    return lines;
+
+        var slashPos = line.indexOf('/');
+        if (slashPos === -1) {
+            // something like "*.js" which we need to interpret as "**/*.js"
+            return '**/' + line;
+        }
+
+        if (slashPos === 0) {
+            // something like "/node_modules" so we need to remove
+            // the leading slash
+            line = line.substring(1);
+        }
+
+        return line;
+    });
 }
 
 function loadIgnoreFiles(ignoreFiles, ignorePatterns) {
@@ -30,6 +39,8 @@ function selectAndLoadIgnoreFile(ignoreFiles, ignorePatterns) {
     for (var i=0; i<ignoreFiles.length; i++) {
         var ignoreFile = ignoreFiles[i];
         if (fs.existsSync(ignoreFile)) {
+            // We found a file that contains ignore patterns.
+            // We only load patterns from the first file that exists
             return ignorePatterns.concat(loadIgnoreFile(ignoreFile));
         }
     }
@@ -49,14 +60,17 @@ function loadIgnorePatterns(options) {
         ignorePatterns = ignorePatterns.concat(loadIgnoreFile(options.ignoreFile));
     }
 
+    // load ignore patterns that might exist in standard files such as .gitignore
     if (options.selectIgnoreFile && options.selectIgnoreFile.length) {
         ignorePatterns = selectAndLoadIgnoreFile(options.selectIgnoreFile, ignorePatterns);
     }
 
+    // if no patterns were loaded from file then use the defaults
     if (ignorePatterns.length === 0 && options.defaultIgnorePatterns) {
         ignorePatterns = options.defaultIgnorePatterns;
     }
 
+    // remove zero-length patterns...
     ignorePatterns = ignorePatterns.filter(function(pattern) {
         return pattern.trim().length > 0;
     });
@@ -64,49 +78,4 @@ function loadIgnorePatterns(options) {
     return ignorePatterns;
 }
 
-function createIgnoredFilter(ignorePatterns, dir) {
-    var ignorePatternsLength = ignorePatterns.length;
-
-    if (!ignorePatternsLength) {
-        return function(path) {
-            return false; // Everything is included
-        };
-    } else {
-        var ignoreMatchers = ignorePatterns.map(function (pattern) {
-            return new Minimatch(pattern, MINIMATCH_OPTIONS);
-        });
-
-        return function(path) {
-            if (path.startsWith(dir)) {
-                path = path.substring(dir.length);
-            }
-
-            path = path.replace(/\\/g, '/');
-
-            var ignore = false;
-
-            for (var i=0; i<ignorePatternsLength; i++) {
-                var matcher = ignoreMatchers[i];
-
-                var match = matcher.match(path);
-
-                if (!match) {
-                    match = matcher.match(path + '/');
-                }
-
-                if (match) {
-                    if (matcher.negate) {
-                        ignore = false;
-                    } else {
-                        ignore = true;
-                    }
-                }
-            }
-
-            return ignore;
-        };
-    }
-}
-
 exports.loadIgnorePatterns = loadIgnorePatterns;
-exports.createIgnoredFilter = createIgnoredFilter;

--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -21,6 +21,10 @@ function _normalizeIgnorePatterns(lines) {
             line = line.substring(1);
         }
 
+        if (line.charAt(line.length - 1) === '/') {
+            line += '**';
+        }
+
         return line;
     });
 }

--- a/lib/ignore.js
+++ b/lib/ignore.js
@@ -1,12 +1,6 @@
 var fs = require('fs');
 
-function loadIgnoreFile(ignoreFile) {
-    var lines = fs.readFileSync(
-        ignoreFile,
-        'utf8')
-        .split(/\s*\r?\n\s*/);
-
-
+function _normalizeIgnorePatterns(lines) {
     return lines.map(function(line) {
         line = line.trim();
 
@@ -31,17 +25,22 @@ function loadIgnoreFile(ignoreFile) {
     });
 }
 
-function loadIgnoreFiles(ignoreFiles, ignorePatterns) {
-    return ignorePatterns.concat(ignoreFiles.map(loadIgnoreFile));
+function _loadIgnoreFile(ignoreFile) {
+    return _normalizeIgnorePatterns(
+        fs.readFileSync(ignoreFile,{encoding:'utf8'}).split(/\s*\r?\n\s*/));
 }
 
-function selectAndLoadIgnoreFile(ignoreFiles, ignorePatterns) {
+function _loadIgnoreFiles(ignoreFiles, ignorePatterns) {
+    return ignorePatterns.concat(ignoreFiles.map(_loadIgnoreFile));
+}
+
+function _selectAndLoadIgnoreFile(ignoreFiles, ignorePatterns) {
     for (var i=0; i<ignoreFiles.length; i++) {
         var ignoreFile = ignoreFiles[i];
         if (fs.existsSync(ignoreFile)) {
             // We found a file that contains ignore patterns.
             // We only load patterns from the first file that exists
-            return ignorePatterns.concat(loadIgnoreFile(ignoreFile));
+            return ignorePatterns.concat(_loadIgnoreFile(ignoreFile));
         }
     }
 
@@ -49,25 +48,25 @@ function selectAndLoadIgnoreFile(ignoreFiles, ignorePatterns) {
     return ignorePatterns;
 }
 
-function loadIgnorePatterns(options) {
-    var ignorePatterns = options.ignorePatterns || [];
+exports.loadIgnorePatterns = function loadIgnorePatterns(options) {
+    var ignorePatterns = _normalizeIgnorePatterns(options.ignorePatterns || []);
 
     if (options.ignoreFiles && options.ignoreFiles.length) {
-        ignorePatterns = loadIgnoreFiles(options.ignoreFiles, ignorePatterns);
+        ignorePatterns = _loadIgnoreFiles(options.ignoreFiles, ignorePatterns);
     }
 
     if (options.ignoreFile && options.ignoreFile.length) {
-        ignorePatterns = ignorePatterns.concat(loadIgnoreFile(options.ignoreFile));
+        ignorePatterns = ignorePatterns.concat(_loadIgnoreFile(options.ignoreFile));
     }
 
     // load ignore patterns that might exist in standard files such as .gitignore
     if (options.selectIgnoreFile && options.selectIgnoreFile.length) {
-        ignorePatterns = selectAndLoadIgnoreFile(options.selectIgnoreFile, ignorePatterns);
+        ignorePatterns = _selectAndLoadIgnoreFile(options.selectIgnoreFile, ignorePatterns);
     }
 
     // if no patterns were loaded from file then use the defaults
     if (ignorePatterns.length === 0 && options.defaultIgnorePatterns) {
-        ignorePatterns = options.defaultIgnorePatterns;
+        ignorePatterns = _normalizeIgnorePatterns(options.defaultIgnorePatterns);
     }
 
     // remove zero-length patterns...
@@ -76,6 +75,4 @@ function loadIgnorePatterns(options) {
     });
 
     return ignorePatterns;
-}
-
-exports.loadIgnorePatterns = loadIgnorePatterns;
+};

--- a/package.json
+++ b/package.json
@@ -1,28 +1,26 @@
 {
-    "name": "ignoring-watcher",
-    "description": "Watch an entire directory tree while ignoring specific directories/files based on .gitignore rules.",
-    "main": "lib/index",
-    "scripts": {},
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/patrick-steele-idem/ignoring-watcher.git"
-    },
-    "keywords": [
-        "watch",
-        "ignore",
-        "file"
-    ],
-    "author": "Patrick Steele-Idem <pnidem@gmail.com>",
-    "license": "ISC",
-    "bugs": {
-        "url": "https://github.com/patrick-steele-idem/ignoring-watcher/issues"
-    },
-    "homepage": "https://github.com/patrick-steele-idem/ignoring-watcher",
-    "dependencies": {
-        "chokidar": "^1.0.5",
-        "minimatch": "^2.0.1",
-        "raptor-polyfill": "^1.0.2",
-        "raptor-util": "^1.0.7"
-    },
-    "version": "1.0.8"
+  "name": "ignoring-watcher",
+  "description": "Watch an entire directory tree while ignoring specific directories/files based on .gitignore rules.",
+  "main": "lib/index",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patrick-steele-idem/ignoring-watcher.git"
+  },
+  "keywords": [
+    "watch",
+    "ignore",
+    "file"
+  ],
+  "author": "Patrick Steele-Idem <pnidem@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/patrick-steele-idem/ignoring-watcher/issues"
+  },
+  "homepage": "https://github.com/patrick-steele-idem/ignoring-watcher",
+  "dependencies": {
+    "chokidar": "^1.0.5",
+    "raptor-util": "^1.0.7"
+  },
+  "version": "1.0.8"
 }


### PR DESCRIPTION
This is a pretty big simplification to use `chokidar`'s built-in support for ignore patterns instead of using `minimatch` module. The ignore patterns from the ignore files (`.gitignore` for example) need to be massaged a little bit.

Patterns that don't contain slash will have `**/` prepended to the start.

For example,
`*.marko.js`

Becomes:
`**/*.marko.js`

Patterns with leading slash will have their leading slash removed (`chokidar` will not correctly handle a pattern that has a leading slash).

**POSSIBLE BREAKING CHANGE:**
Patterns to ignore directories should end with a slash (e.g. `node_modules/` instead of `node_modules`)

Patterns that end with slash will have `**` appended to the end.

For example,
`node_modules/`

Becomes:
`node_modules/**`
